### PR TITLE
Fixed memory leaks found by Heob

### DIFF
--- a/test/fmi1me/fmi1me.c
+++ b/test/fmi1me/fmi1me.c
@@ -4,6 +4,7 @@
 #include "fmi4c_common.h"
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
 #define VR_DX 1
 #define VR_X 2
@@ -126,8 +127,8 @@ DllExport fmiComponent fmiInstantiateModel(fmiString  instanceName,
                                            fmiBoolean loggingOn)
 {
     fmuContext *fmu = malloc(sizeof(fmuContext));
-    fmu->instanceName = instanceName;
-    fmu->guid = fmuGUID;
+    fmu->instanceName = _strdup(instanceName);
+    fmu->guid = _strdup(fmuGUID);
     fmu->callbacks = functions;
     fmu->loggingOn = loggingOn;
 

--- a/test/fmi2/fmi2.c
+++ b/test/fmi2/fmi2.c
@@ -4,6 +4,7 @@
 #include "fmi4c_common.h"
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
 #define VR_DX 1
 #define VR_X 2
@@ -44,8 +45,8 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
     UNUSED(visible);
 
     fmuContext *fmu = malloc(sizeof(fmuContext));
-    fmu->instanceName = instanceName;
-    fmu->guid = fmuGUID;
+    fmu->instanceName = _strdup(instanceName);
+    fmu->guid = _strdup(fmuGUID);
     fmu->type = fmuType;
     fmu->callbacks = functions;
     fmu->loggingOn = loggingOn;
@@ -59,6 +60,8 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
 
 void fmi2FreeInstance(fmi2Component c) {
     fmuContext *fmu = (fmuContext*)c;
+    free((char*)fmu->instanceName);
+    free((char*)fmu->guid);
     free(fmu);
 }
 

--- a/test/fmi3/fmi3.c
+++ b/test/fmi3/fmi3.c
@@ -4,6 +4,7 @@
 #include "fmi4c_common.h"
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
 #define VR_DX 1
 #define VR_X 2
@@ -11,6 +12,7 @@
 typedef struct {
     fmi3String instanceName;
     fmi3String instantiationToken;
+    fmi3String resourcePath;
     fmi3InstanceEnvironment fmi3InstanceEnvironment;
     fmi3LogMessageCallback logger;
     fmi3IntermediateUpdateCallback intermediateUpdate;
@@ -52,8 +54,8 @@ fmi3Instance fmi3InstantiateModelExchange(fmi3String instanceName,
     UNUSED(visible);
 
     fmuContext *fmu = malloc(sizeof(fmuContext));
-    fmu->instanceName = instanceName;
-    fmu->instantiationToken = instantiationToken;
+    fmu->instanceName = _strdup(instanceName);
+    fmu->instantiationToken = _strdup(instantiationToken);
     fmu->fmi3InstanceEnvironment = instanceEnvironment;
     fmu->logger = logMessage;
     fmu->loggingOn = loggingOn;
@@ -83,8 +85,9 @@ fmi3Instance fmi3InstantiateCoSimulation(fmi3String instanceName,
 
     fmuContext *fmu = malloc(sizeof(fmuContext));
 
-    fmu->instanceName = instanceName;
-    fmu->instantiationToken = instantiationToken;
+    fmu->instanceName = _strdup(instanceName);
+    fmu->instantiationToken = _strdup(instantiationToken);
+    fmu->resourcePath = resourcePath;
     fmu->fmi3InstanceEnvironment = instanceEnvironment;
     fmu->logger = logMessage;
     fmu->intermediateUpdate = intermediateUpdate;
@@ -122,6 +125,8 @@ fmi3Instance fmi3InstantiateScheduledExecution(fmi3String instanceName,
 void fmi3FreeInstance(fmi3Instance instance)
 {
     fmuContext *fmu = (fmuContext*)instance;
+    free((char*)fmu->instanceName);
+    free((char*)fmu->instantiationToken);
     free(fmu);
 }
 

--- a/test/fmi4c_test.c
+++ b/test/fmi4c_test.c
@@ -246,21 +246,29 @@ int main(int argc, char *argv[])
         printf("FMI TLM support not available\n");
         return 1;
 #else
-        return testFMI3TLM(fmu, fmu2, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
+        int retval = testFMI3TLM(fmu, fmu2, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
+        freeFmu(fmu);
+        freeFmu(fmu2);
+        return retval;
 #endif
     }
 
+    int retval;
     if(version == fmiVersion1) {
-        return testFMI1(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
+        retval = testFMI1(fmu, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
     else if(version == fmiVersion2) {
-        return testFMI2(fmu, forceModelExchange, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
+        retval = testFMI2(fmu, forceModelExchange, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
     else {
-        return testFMI3(fmu, forceModelExchange, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
+        retval = testFMI3(fmu, forceModelExchange, overrideStopTime, stopTimeOverride, overrideTimeStep, timeStepOverride);
     }
 
-    return 0;
+    freeFmu(fmu);
+
+
+
+    return retval;
 }
 
 

--- a/test/fmi4c_test_fmi1.c
+++ b/test/fmi4c_test_fmi1.c
@@ -210,6 +210,10 @@ int testFMI1ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
         fprintf(outputFile,"\n");
     }
     fclose(outputFile);
+    free(derivatives);
+    free(eventIndicatorsPrev);
+    free(states);
+    free(eventIndicators);
 
     printf("  Simulation finished.\n");
 

--- a/test/fmi4c_test_fmi2.c
+++ b/test/fmi4c_test_fmi2.c
@@ -143,6 +143,10 @@ int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
             fmi2VariableHandle *var = fmi2GetVariableByName(fmu, interpolationData[i].name);
             if(var == NULL) {
                 printf("Variable in input file does not exist in FMU: %s\n", interpolationData[i].name);
+                free(derivatives);
+                free(eventIndicatorsPrev);
+                free(states);
+                free(eventIndicators);
                 return 1;
             }
             fmi2Real value = interpolate(&interpolationData[0], &interpolationData[i], time, dataSize);
@@ -249,6 +253,10 @@ int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
         }
         fprintf(outputFile,"\n");
     }
+    free(derivatives);
+    free(eventIndicatorsPrev);
+    free(states);
+    free(eventIndicators);
     fclose(outputFile);
 
     printf("  Simulation finished.\n");
@@ -257,6 +265,7 @@ int testFMI2ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
     printf("  FMU successfully terminated.\n");
 
     fmi2FreeInstance(fmu);
+
     return 0;
 }
 

--- a/test/fmi4c_test_fmi3.c
+++ b/test/fmi4c_test_fmi3.c
@@ -336,6 +336,11 @@ int testFMI3ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
             fmi3VariableHandle *var = fmi3GetVariableByName(fmu, interpolationData[i].name);
             if(var == NULL) {
                 printf("Variable in input file does not exist in FMU: %s\n", interpolationData[i].name);
+                free(derivatives);
+                free(eventIndicatorsPrev);
+                free(rootsFound);
+                free(states);
+                free(eventIndicators);
                 return 1;
             }
             fmi3Float64 value = interpolate(&interpolationData[0], &interpolationData[i], time, dataSize);
@@ -383,7 +388,11 @@ int testFMI3ME(fmiHandle *fmu, bool overrideStopTime, double stopTimeOverride, b
 
         fmi3CompletedIntegratorStep(fmu, fmi3True, &stepEvent, &terminateSimulation);
     }
-
+    free(derivatives);
+    free(eventIndicatorsPrev);
+    free(rootsFound);
+    free(states);
+    free(eventIndicators);
     printf("  Simulation finished.\n");
 
     fmi3Terminate(fmu);


### PR DESCRIPTION
A few leaks still remain, but they are a consequence of other structural problems with the code. In particular, we need to separate data from different FMU types. For example, the instanceName can be different for model exchange and co-simulation. Right now it is loaded for both, resulting in one being over-written (= memory leak).