### PR TITLE
Improved management of platform tuples

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceRoot}/<your program>",
+      "args": [],
+      "cwd": "${workspaceRoot}"
+    }
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(fmi4c C)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 11)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -26,6 +26,9 @@
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
     #define bits_str "64"
+#elif defined(__arm64__) || defined(__aarch64__)
+    #define arch_str "aarch64"
+    #define bits_str "64"
 #else
     #define bits_str "32"
 #endif

--- a/src/fmi4c.c
+++ b/src/fmi4c.c
@@ -2336,8 +2336,6 @@ bool loadFunctionsFmi3(fmuHandle *fmu, fmi3Type fmuType)
 
     fmu->dll = dll;
 
-    printf("Loading FMI version 3...\n");
-
     //Load all common functions
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,9 @@ if(APPLE)
   endif()
 endif()
 
+# Set default debug postfix
+set(CMAKE_DEBUG_POSTFIX "")
+
 set(fmi4ctest_src fmi4c_test.c
                   fmi4c_test_fmi1.c
                   fmi4c_test_fmi2.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,7 @@ else()
   set(binfolder linux64)
 endif()
 
+
 add_library(fmi1cs SHARED fmi1cs/fmi1cs.c)
 set_target_properties(fmi1cs PROPERTIES PREFIX "")
 set_target_properties(fmi1cs PROPERTIES DEBUG_POSTFIX "")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,16 @@ if (NOT MSVC)
   set(libmath m)
 endif()
 
+if(APPLE)
+  if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
+    message(STATUS "Apple Silicon detected")
+    set(APPLE_ARCH aarch64)
+  elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64")
+    message(STATUS "Intel Mac detected")
+    set(APPLE_ARCH x86_64)
+  endif()
+endif()
+
 set(fmi4ctest_src fmi4c_test.c
                   fmi4c_test_fmi1.c
                   fmi4c_test_fmi2.c

--- a/test/fmi4c_test.c
+++ b/test/fmi4c_test.c
@@ -71,8 +71,7 @@ void printUsage() {
 
 void messageCallback(const char* msg)
 {
-    printf(msg);
-    printf("\n");
+    printf("%s\n", msg);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR fixes some runtime errors related to the wrong management of platform tuples when generating tests and when loading from temporary unzipped folder, especially when run on macOS.

Changes are on the `CMakeLists.txt` for tests (so that the `.fmu` zips are generated according to specs) and to the `fmi4c.c` main source file (so that the unzipped contents are properly searched).

Now all the test pass on macOS and on Linux (haven't tested on Windows, but I have made no changes that involve that platform).